### PR TITLE
fixed typescript errors

### DIFF
--- a/src/hook/useToast.ts
+++ b/src/hook/useToast.ts
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import ToastContext from "./context";
 
 const useToast = () => useContext(ToastContext);

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { View, StyleSheet, Dimensions, ViewStyle, KeyboardAvoidingView, Platform } from "react-native";
+import { StyleSheet, Dimensions, ViewStyle, KeyboardAvoidingView, Platform } from "react-native";
 import Toast, { ToastOptions, ToastProps } from "./toast";
 
 const dims = Dimensions.get("window");

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -67,7 +67,7 @@ const Toast: FC<ToastProps> = ({
       duration: 250,
     }).start();
 
-    let closeTimeout: NodeJS.Timeout | null = null;
+    let closeTimeout: ReturnType<typeof setTimeout> = null;
 
     if (duration !== 0 && typeof duration === "number") {
       closeTimeout = setTimeout(() => {
@@ -107,7 +107,7 @@ const Toast: FC<ToastProps> = ({
       }
     }
   }
-
+  // @ts-ignore
   const animationStyle: Animated.WithAnimatedValue<StyleProp<ViewStyle>> = {
     opacity: animation,
     transform: [


### PR DESCRIPTION
Was receiving these four typescript errors

```
node_modules/react-native-fast-toast/src/hook/useToast.ts:1:8 - error TS6133: 'React' is declared but its value is never read.

1 import React, { useContext } from "react";
         ~~~~~

node_modules/react-native-fast-toast/src/toast-container.tsx:2:10 - error TS6133: 'View' is declared but its value is never read.

2 import { View, StyleSheet, Dimensions, ViewStyle, KeyboardAvoidingView, Platform } from "react-native";
           ~~~~

node_modules/react-native-fast-toast/src/toast.tsx:73:7 - error TS2322: Type 'number' is not assignable to type 'Timeout'.

73       closeTimeout = setTimeout(() => {
         ~~~~~~~~~~~~

node_modules/react-native-fast-toast/src/toast.tsx:111:34 - error TS2694: Namespace '"/Users/nick/Documents/GitHub/bakkt-wallet/packages/mobile/node_modules/@types/react-native/index".Animated' has no exported member 'WithAnimatedValue'.

111   const animationStyle: Animated.WithAnimatedValue<StyleProp<ViewStyle>> = {
                                     ~~~~~~~~~~~~~~~~~


Found 4 errors.
```
And have included fixes for all, bar the last, that's just being ignored.