### PR TITLE
remove setting width explicitly and allow Toast Container to occupy as much space as Toast needs

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import Toast, { ToastOptions, ToastProps } from "./toast";
 
-const { height, width } = Dimensions.get("window");
+const { height } = Dimensions.get("window");
 
 export interface Props extends ToastOptions {
   renderToast?(toast: ToastProps): JSX.Element;
@@ -114,7 +114,6 @@ class ToastContainer extends Component<Props, State> {
     let { offset, offsetBottom } = this.props;
     let style: ViewStyle = {
       bottom: offsetBottom || offset,
-      width: width,
       justifyContent: "flex-end",
       flexDirection: "column",
     };
@@ -138,7 +137,6 @@ class ToastContainer extends Component<Props, State> {
     let { offset, offsetTop } = this.props;
     let style: ViewStyle = {
       top: offsetTop || offset,
-      width: width,
       justifyContent: "flex-start",
       flexDirection: "column-reverse",
     };
@@ -163,7 +161,6 @@ class ToastContainer extends Component<Props, State> {
     let style: ViewStyle = {
       top: offsetTop || offset,
       height: height,
-      width: width,
       justifyContent: "center",
       flexDirection: "column-reverse",
     };


### PR DESCRIPTION
#135 and #140 introduced a regression which was fixed by me in #126 where touchable elements to the side of the toast are not pressable because toast container overlaps them

Fixes #147 