### PR TITLE
Fix iOS shaking toasts when placement is bottom

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -120,7 +120,7 @@ class ToastContainer extends Component<Props, State> {
     };
     let safeAreaStyle: ViewStyle = {
       flex: 1
-    }
+    };
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -118,13 +118,16 @@ class ToastContainer extends Component<Props, State> {
       justifyContent: "flex-end",
       flexDirection: "column",
     };
+    let safeAreaStyle: ViewStyle = {
+      flex: 1
+    }
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
         style={[styles.container, style]}
         pointerEvents="box-none"
       >
-        <SafeAreaView>
+        <SafeAreaView style={safeAreaStyle}>
           {toasts
             .filter((t) => !t.placement || t.placement === "bottom")
             .map((toast) => (


### PR DESCRIPTION
PR aims to fix a bug on toasts on iOS.

To reproduce bug (on iOS) :
- Add a Toast Provider
- Add a custom toast render (or use the default one)
- Use bottom placement
- Trigger multiple toasts. When hiding, toasts are jittering up and down.

This PR aims to fix a bug with Toasts shaking when placed at the bottom of the screen. Similar bug is described here (https://github.com/facebook/react-native/issues/27049) and a possible solution is shown here (https://github.com/react-native-modal/react-native-modal/issues/463). This fix also works here, without noticeable side effects. 

