### PR TITLE
Fixed not working swipe gestures when toast is shown from React-Native Modal

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -211,6 +211,7 @@ const Toast: FC<ToastProps> = (props) => {
     if (panResponderRef.current) return panResponderRef.current;
     const swipeThreshold = Platform.OS === "android" ? 10 : 0;
     panResponderRef.current = PanResponder.create({
+      onStartShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponder: (_, gestureState) => {
         //return true if user is swiping, return false if it's a single click
         return (


### PR DESCRIPTION
I've added missing PanResponder [method](https://reactnative.dev/docs/panresponder#methods) like it was suggested in this [issue](https://github.com/facebook/react-native/issues/14295#issuecomment-463699440) in React-Native GitHub repo. Now the swiping actions works inside React-Native Modal too.

This PR aims to fix issue #158.