### PR TITLE
feat: Add toast type function (success, danger, warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ toast.show("Task finished successfully", {
 });
 ```
 
+### success(), danger(), warning()
+```js
+toast.success("success");
+toast.danger("danger");
+toast.warning("warning");
+```
+
 ### update()
 
 ```js

--- a/src/hook/context.ts
+++ b/src/hook/context.ts
@@ -3,7 +3,7 @@ import ToastContainer from "../toast-container";
 
 export type ToastType = Pick<
   ToastContainer,
-  "show" | "update" | "hide" | "hideAll" | "isOpen"
+  "show" | "success" | "danger" | "warning" | "update" | "hide" | "hideAll" | "isOpen"
 >;
 
 const ToastContext = React.createContext({} as ToastType);

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -43,6 +43,21 @@ class ToastContainer extends Component<Props, State> {
   show = (message: string | JSX.Element, toastOptions?: ToastOptions) => this.renderToast(message, toastOptions)
 
   /**
+   * Shows a new success toast. Returns id
+   */
+  success = (message: string | JSX.Element, toastOptions?: ToastOptions) => this.renderToast(message, { type: "success", ...toastOptions })
+
+  /**
+   * Shows a new danger toast. Returns id
+   */
+  danger = (message: string | JSX.Element, toastOptions?: ToastOptions) => this.renderToast(message, { type: "danger", ...toastOptions })
+
+  /**
+   * Shows a new warning toast. Returns id
+   */
+  warning = (message: string | JSX.Element, toastOptions?: ToastOptions) => this.renderToast(message, { type: "warning", ...toastOptions })
+
+  /**
    * Updates a toast, To use this create you must pass an id to show method first, then pass it here to update the toast.
    */
   update = (

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -40,32 +40,7 @@ class ToastContainer extends Component<Props, State> {
   /**
    * Shows a new toast. Returns id
    */
-  show = (message: string | JSX.Element, toastOptions?: ToastOptions) => {
-    let id = toastOptions?.id || Math.random().toString();
-    const onDestroy = () => {
-      toastOptions?.onClose && toastOptions?.onClose();
-      this.setState({ toasts: this.state.toasts.filter((t) => t.id !== id) });
-    };
-
-    requestAnimationFrame(() => {
-      this.setState({
-        toasts: [
-          {
-            id,
-            onDestroy,
-            message,
-            open: true,
-            onHide: () => this.hide(id),
-            ...this.props,
-            ...toastOptions,
-          },
-          ...this.state.toasts.filter((t) => t.open),
-        ],
-      });
-    });
-
-    return id;
-  };
+  show = (message: string | JSX.Element, toastOptions?: ToastOptions) => this.renderToast(message, toastOptions)
 
   /**
    * Updates a toast, To use this create you must pass an id to show method first, then pass it here to update the toast.
@@ -107,6 +82,33 @@ class ToastContainer extends Component<Props, State> {
    */
   isOpen = (id: string) => {
     return this.state.toasts.some((t) => t.id === id && t.open);
+  }
+
+  renderToast(message: string | JSX.Element, toastOptions?: ToastOptions) {
+    let id = toastOptions?.id || Math.random().toString();
+    const onDestroy = () => {
+      toastOptions?.onClose && toastOptions?.onClose();
+      this.setState({ toasts: this.state.toasts.filter((t) => t.id !== id) });
+    };
+
+    requestAnimationFrame(() => {
+      this.setState({
+        toasts: [
+          {
+            id,
+            onDestroy,
+            message,
+            open: true,
+            onHide: () => this.hide(id),
+            ...this.props,
+            ...toastOptions,
+          },
+          ...this.state.toasts.filter((t) => t.open),
+        ],
+      });
+    });
+
+    return id;
   }
 
   renderBottomToasts() {


### PR DESCRIPTION
Add a toast type function to make it easier to use, similar to another toast library. e.g.
A. [react-hot-toast](https://react-hot-toast.com/docs/toast)

<img width="668" alt="截圖 2024-07-29 00 45 50" src="https://github.com/user-attachments/assets/05906677-26d9-4563-ab8f-562ba722f1f0">

B. [react-toastify](https://fkhadra.github.io/react-toastify/positioning-toast)

<img width="354" alt="截圖 2024-07-29 00 46 31" src="https://github.com/user-attachments/assets/864635be-2186-446e-89b3-460fa18dd378">