### PR TITLE
feat: Add custom toast container wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ You can implement your own custom types or overwrite the existing ones
 toast.show("Show custom toast", {data: { title: 'Toast title' }})
 ```
 
+### Custom toast container wrapper
+
+You can wrap a toast container with a custom wrapper.
+
+
+```js
+<ToastProvider
+    ToastContainerWrapper={{
+      component: FooComponent,
+      props: {style: { flex: 1}}
+    }}
+>
+...
+</>
+
+// In order to display a toast over a native-stack modal, use [FullWindowOverlay component](https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#fullwindowoverlay).
+
+```
+
+
 ## FAQ
 
 ### - How to call toast outside React components?

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -4,7 +4,8 @@ import {
   ViewStyle,
   KeyboardAvoidingView,
   Platform,
-  Dimensions, SafeAreaView,
+  Dimensions,
+  SafeAreaView,
 } from "react-native";
 import Toast, { ToastOptions, ToastProps } from "./toast";
 
@@ -17,6 +18,10 @@ export interface Props extends ToastOptions {
   offsetTop?: number;
   offsetBottom?: number;
   swipeEnabled?: boolean;
+  ToastContainerWrapper?: {
+    component: React.ComponentType<any>;
+    props: any;
+  };
 }
 
 interface State {
@@ -107,7 +112,7 @@ class ToastContainer extends Component<Props, State> {
    */
   isOpen = (id: string) => {
     return this.state.toasts.some((t) => t.id === id && t.open);
-  }
+  };
 
   renderBottomToasts() {
     const { toasts } = this.state;
@@ -118,6 +123,7 @@ class ToastContainer extends Component<Props, State> {
       justifyContent: "flex-end",
       flexDirection: "column",
     };
+
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
@@ -132,7 +138,7 @@ class ToastContainer extends Component<Props, State> {
             ))}
         </SafeAreaView>
       </KeyboardAvoidingView>
-    );
+    )
   }
 
   renderTopToasts() {
@@ -193,7 +199,15 @@ class ToastContainer extends Component<Props, State> {
   }
 
   render() {
-    return (
+    const { ToastContainerWrapper } = this.props;
+
+    return ToastContainerWrapper ? (
+      <ToastContainerWrapper.component {...ToastContainerWrapper.props}>
+        {this.renderTopToasts()}
+        {this.renderBottomToasts()}
+        {this.renderCenterToasts()}
+      </ToastContainerWrapper.component>
+    ) : (
       <>
         {this.renderTopToasts()}
         {this.renderBottomToasts()}
@@ -211,8 +225,10 @@ const styles = StyleSheet.create({
     maxWidth: "100%",
     zIndex: 999999,
     elevation: 999999,
-    alignSelf: 'center',
-    ...(Platform.OS === "web" ? { overflow: "hidden", userSelect: 'none' } : null),
+    alignSelf: "center",
+    ...(Platform.OS === "web"
+      ? { overflow: "hidden", userSelect: "none" }
+      : null),
   },
   message: {
     color: "#333",

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -22,6 +22,7 @@ export interface Props extends ToastOptions {
     component: React.ComponentType<any>;
     props: any;
   };
+  containerStyle?: ViewStyle
 }
 
 interface State {
@@ -116,7 +117,7 @@ class ToastContainer extends Component<Props, State> {
 
   renderBottomToasts() {
     const { toasts } = this.state;
-    let { offset, offsetBottom } = this.props;
+    let { offset, offsetBottom, containerStyle } = this.props;
     let style: ViewStyle = {
       bottom: offsetBottom || offset,
       width: width,
@@ -127,7 +128,7 @@ class ToastContainer extends Component<Props, State> {
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
-        style={[styles.container, style]}
+        style={[styles.container, style, containerStyle]}
         pointerEvents="box-none"
       >
         <SafeAreaView>
@@ -143,7 +144,7 @@ class ToastContainer extends Component<Props, State> {
 
   renderTopToasts() {
     const { toasts } = this.state;
-    let { offset, offsetTop } = this.props;
+    let { offset, offsetTop, containerStyle } = this.props;
     let style: ViewStyle = {
       top: offsetTop || offset,
       width: width,
@@ -153,7 +154,7 @@ class ToastContainer extends Component<Props, State> {
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
-        style={[styles.container, style]}
+        style={[styles.container, style, containerStyle]}
         pointerEvents="box-none"
       >
         <SafeAreaView>
@@ -169,7 +170,7 @@ class ToastContainer extends Component<Props, State> {
 
   renderCenterToasts() {
     const { toasts } = this.state;
-    let { offset, offsetTop } = this.props;
+    let { offset, offsetTop, containerStyle } = this.props;
     let style: ViewStyle = {
       top: offsetTop || offset,
       height: height,
@@ -186,7 +187,7 @@ class ToastContainer extends Component<Props, State> {
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
-        style={[styles.container, style]}
+        style={[styles.container, style, containerStyle]}
         pointerEvents="box-none"
       >
         {toasts


### PR DESCRIPTION
Add a custom toast container wrapper.

Wrapping the toast container with [FullWindowOverlay](https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#fullwindowoverlay) enables the toast to work with react navigation native-stack. Prior to this adjustment, the toasts were hidden behind the modal.

Also exposed `containerStyle` for custom toast container styles.
