### PR TITLE
added testID to toastOptions

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -112,6 +112,11 @@ export interface ToastOptions {
   data?: any;
 
   swipeEnabled?: boolean;
+
+  /**
+   * Unique identifier for testing purposes
+   */
+  testID?: string;
 }
 
 export interface ToastProps extends ToastOptions {
@@ -146,6 +151,7 @@ const Toast: FC<ToastProps> = (props) => {
     placement,
     swipeEnabled,
     onPress,
+    testID
   } = props;
 
   const containerRef = useRef<View>(null);
@@ -329,6 +335,7 @@ const Toast: FC<ToastProps> = (props) => {
           onPress={() => onPress && onPress(id)}
         >
           <View
+            testID={testID}
             style={[
               styles.toastContainer,
               { maxWidth: (dims.width / 10) * 9, backgroundColor },


### PR DESCRIPTION
When using e2e tests (for example with detox or maestro) you want to have a testID to check if the toast message is visible or not. 

Fix for issue: #188 